### PR TITLE
Ugly hack to fix Excel button

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -502,7 +502,9 @@ DataTable.ext.buttons.excelHtml5 = {
 		var data = dt.buttons.exportData( config.exportOptions );
 		var addRow = function ( row ) {
 			var cells = [];
-
+			if (row == null){
+			     row = 0;
+			}
 			for ( var i=0, ien=row.length ; i<ien ; i++ ) {
 				cells.push( $.isNumeric( row[i] ) ?
 					'<c t="n"><v>'+row[i]+'</v></c>' :


### PR DESCRIPTION
The following line was breaking the entire functionality of an excel button, because at the last iteration "row" variable gets a null value, so row.length throws an error:
`for ( var i=0, ien=row.length ; i<ien ; i++ ) {`
I just put the proposed code to temporarily fix it.