### PR TITLE
Add ;charset=utf-8 to csv blob type

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -483,7 +483,7 @@ DataTable.ext.buttons.csvHtml5 = {
 		var output = _exportData( dt, config ).str;
 
 		_saveAs(
-			new Blob( [output], {type : 'text/csv'} ),
+			new Blob( [output], {type : 'text/csv;charset=utf-8'} ),
 			_filename( config )
 		);
 	},


### PR DESCRIPTION
FileSaver.js adds a BOM to the csv file if the blob has the type `text/*` and includes `;charset=utf-8`. Since the blob type currently is `text/csv` I simply added `;charset=utf-8` to make this work. The reason I found myself to want FileSaver to add BOM to the csv file was that Excel didn't display utf-8 characters without it.

I suppose a more thorough solution would be to let the user choose a custom blob type. Would you accept a pull request for that?