### PR TITLE
Prevent error when exporting to HTML5 CSV when data contains numbers

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -309,7 +309,7 @@ var _exportData = function ( dt, config )
 			}
 
 			s += boundary ?
-				boundary + a[i].replace( reBoundary, '\\'+boundary ) + boundary :
+				boundary + ('' + a[i]).replace( reBoundary, '\\'+boundary ) + boundary :
 				a[i];
 		}
 


### PR DESCRIPTION
When the datatable contains non-string data (i.e. numbers) currently this line fails when trying to call "replace". I've just added a string addition to ensure it's a string at this point.