### PR TITLE
Update buttons.colVis.js

### DIFF
--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -84,7 +84,9 @@ $.extend( DataTable.ext.buttons, {
 				.on( 'column-reorder.dt'+conf.namespace, function (e, settings, details) {
 					var col = dt.column( conf.columns );
 
-					button.children().text( conf._columnText( dt, conf.columns ) );
+					var btn = button.children() ? button.children() : button;
+					
+					btn.children().text( conf._columnText( dt, conf.columns ) );
 					that.active( col.visible() );
 				} );
 

--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -84,7 +84,7 @@ $.extend( DataTable.ext.buttons, {
 				.on( 'column-reorder.dt'+conf.namespace, function (e, settings, details) {
 					var col = dt.column( conf.columns );
 
-					button.text( conf._columnText( dt, conf.columns ) );
+					button.children().text( conf._columnText( dt, conf.columns ) );
 					that.active( col.visible() );
 				} );
 

--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -85,8 +85,7 @@ $.extend( DataTable.ext.buttons, {
 					var col = dt.column( conf.columns );
 
 					var btn = button.children() ? button.children() : button;
-					
-					btn.children().text( conf._columnText( dt, conf.columns ) );
+					btn.text( conf._columnText( dt, conf.columns ) );
 					that.active( col.visible() );
 				} );
 


### PR DESCRIPTION
Preventing the reordering of columns from replacing the `<span>` child tags in normal datatables styling of the visibility buttons or the  `<a>` tags used on the button when using bootstrap styling.  This patch fixes the first part of issue #26.