### PR TITLE
Added 'prefix' and 'suffix' options to 'csvHtml5' button.

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -562,15 +562,19 @@ DataTable.ext.buttons.excelHtml5 = {
 			return '<row>'+cells.join('')+'</row>';
 		};
 
-                if ( config.prefix ) {
-                        if (config.prefix.reverse) {
-                                config.prefix.forEach(function(p) {
-                                        xml += addRow(p)
-                                });
+                var addLines = function( value ) {
+                        if (value) {
+                                if (value.reverse) {
+                                        value.forEach( function( v ) {
+                                                xml += '<c t="inlineStr"><is><t>' + v + '</t></is></c>';
+                                        } );
+                                }
                         } else {
-                                xml += addRow(config.prefix);
+                                xml += '<c t="inlineStr"><is><t>' + value + '</t></is></c>';
                         }
-                }
+                };
+
+                addLines(config.prefix);
 
 		if ( config.header ) {
 			xml += addRow( data.header );
@@ -584,15 +588,7 @@ DataTable.ext.buttons.excelHtml5 = {
 			xml += addRow( data.footer );
 		}
 
-                if ( config.suffix ) {
-                        if (config.suffix.reverse) {
-                                config.suffix.forEach(function(p) {
-                                        xml += addRow(p);
-                                });
-                        } else {
-                                xml += addRow(config.suffix);
-                        }
-                }
+                addLines(config.suffix);
 
 		var zip           = new window.JSZip();
 		var _rels         = zip.folder("_rels");

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -319,7 +319,7 @@ var _exportData = function ( dt, config )
         var prefix = '';
 	var header = config.header ? join( data.header )+newLine : '';
 	var footer = config.footer ? newLine+join( data.footer ) : '';
-        var suffix = '';
+        var postfix = '';
 	var body = [];
 
 	if (config.prefix) {
@@ -336,18 +336,18 @@ var _exportData = function ( dt, config )
 		body.push( join( data.body[i] ) );
 	}
 
-	if (config.suffix) {
-		if (config.suffix.forEach) {
-			config.suffix.forEach(function(s) {
-                                suffix += newLine + s;
+	if (config.postfix) {
+		if (config.postfix.forEach) {
+			config.postfix.forEach(function(s) {
+                                postfix += newLine + s;
 			});
 		} else {
-                        suffix += newLine + config.suffix;
+                        postfix += newLine + config.postfix;
 		}
 	}
 
 	return {
-		str: prefix + header + body.join( newLine ) + footer + suffix,
+		str: prefix + header + body.join( newLine ) + footer + postfix,
 		rows: body.length
 	};
 };
@@ -526,7 +526,7 @@ DataTable.ext.buttons.csvHtml5 = {
 
 	prefix: null,
 
-	suffix: null
+	postfix: null
 };
 
 //
@@ -590,19 +590,19 @@ DataTable.ext.buttons.excelHtml5 = {
 			xml += addRow( data.footer );
 		}
 
-                addLines(config.suffix);
+		addLines(config.postfix);
 
-		var zip           = new window.JSZip();
-		var _rels         = zip.folder("_rels");
-		var xl            = zip.folder("xl");
-		var xl_rels       = zip.folder("xl/_rels");
+		var zip		  = new window.JSZip();
+		var _rels	  = zip.folder("_rels");
+		var xl		  = zip.folder("xl");
+		var xl_rels	  = zip.folder("xl/_rels");
 		var xl_worksheets = zip.folder("xl/worksheets");
 
-		zip.file(           '[Content_Types].xml', excelStrings['[Content_Types].xml'] );
-		_rels.file(         '.rels',               excelStrings['_rels/.rels'] );
-		xl.file(            'workbook.xml',        excelStrings['xl/workbook.xml'] );
-		xl_rels.file(       'workbook.xml.rels',   excelStrings['xl/_rels/workbook.xml.rels'] );
-		xl_worksheets.file( 'sheet1.xml',          excelStrings['xl/worksheets/sheet1.xml'].replace( '__DATA__', xml ) );
+		zip.file(	    '[Content_Types].xml', excelStrings['[Content_Types].xml'] );
+		_rels.file(	    '.rels',		   excelStrings['_rels/.rels'] );
+		xl.file(	    'workbook.xml',	   excelStrings['xl/workbook.xml'] );
+		xl_rels.file(	    'workbook.xml.rels',   excelStrings['xl/_rels/workbook.xml.rels'] );
+		xl_worksheets.file( 'sheet1.xml',	   excelStrings['xl/worksheets/sheet1.xml'].replace( '__DATA__', xml ) );
 
 		_saveAs(
 			zip.generate( {type:"blob"} ),
@@ -724,33 +724,33 @@ DataTable.ext.buttons.pdfHtml5 = {
 			} );
 		}
 
-                if ( config.prefix ) {
-                        if ( config.prefix.reverse ) {
-                                config.prefix.reverse().forEach( function(p) {
-                                        doc.content.unshift( {
-                                                text: p,
-                                                style: 'message'
-                                        } );
-                                } );
-                        } else {
-                                doc.content.unshift( {
-                                        text: config.prefix,
-                                        style: 'message'
-                                } );
-                        }
-                }
+		if ( config.prefix ) {
+			if ( config.prefix.reverse ) {
+				config.prefix.reverse().forEach( function(p) {
+					doc.content.unshift( {
+						text: p,
+						style: 'message'
+					} );
+				} );
+			} else {
+				doc.content.unshift( {
+					text: config.prefix,
+					style: 'message'
+				} );
+			}
+		}
 
-                if ( config.suffix ) {
-                        if ( config.suffix.reverse ) {
-                                config.suffix.forEach( function(s) {
-                                        doc.content.push( {
-                                                text: s,
-                                                style: 'message'
-                                        } );
-                                } );
-                        } else {
-                                doc.content.push( {
-                                        text: config.suffix,
+		if ( config.postfix ) {
+			if ( config.postfix.reverse ) {
+				config.postfix.forEach( function(s) {
+					doc.content.push( {
+						text: s,
+						style: 'message'
+					} );
+				} );
+			} else {
+				doc.content.push( {
+                                        text: config.postfix,
                                         style: 'message'
                                 } );
                         }

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -485,8 +485,8 @@ DataTable.ext.buttons.csvHtml5 = {
 		var ary = [ output ];
 
 		if (config.prefix) {
-			if (config.prefix.forEach) {
-				config.prefix.forEach(function(p) {
+			if (config.prefix.reverse) {
+				config.prefix.reverse().forEach(function(p) {
 					ary.unshift(newLine);
 					ary.unshift(p);
 				});

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -316,19 +316,19 @@ var _exportData = function ( dt, config )
 		return s;
 	};
 
+        var prefix = '';
 	var header = config.header ? join( data.header )+newLine : '';
 	var footer = config.footer ? newLine+join( data.footer ) : '';
+        var suffix = '';
 	var body = [];
 
 	if (config.prefix) {
 		if (config.prefix.reverse) {
-			config.prefix.reverse().forEach(function(p) {
-				body.unshift(newLine);
-				body.unshift(p);
+			config.prefix.forEach(function(p) {
+                                prefix += p + newLine;
 			});
 		} else {
-			body.unshift(newLine);
-			body.unshift(config.prefix);
+                        prefix = config.prefix + newLine;
 		}
 	}
 
@@ -339,17 +339,15 @@ var _exportData = function ( dt, config )
 	if (config.suffix) {
 		if (config.suffix.forEach) {
 			config.suffix.forEach(function(s) {
-				body.push(newLine);
-				body.push(s);
+                                suffix += newLine + s;
 			});
 		} else {
-			body.push(newLine);
-			body.push(config.suffix);
+                        suffix += newLine + config.suffix;
 		}
 	}
 
 	return {
-		str: header + body.join( newLine ) + footer,
+		str: prefix + header + body.join( newLine ) + footer + suffix,
 		rows: body.length
 	};
 };

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -485,8 +485,8 @@ DataTable.ext.buttons.csvHtml5 = {
 		var ary = [ output ];
 
 		if (config.prefix) {
-			if (config.prefix.reverse) {
-				config.prefix.reverse().forEach(function(p) {
+			if (config.prefix.forEach) {
+				config.prefix.forEach(function(p) {
 					ary.unshift(newLine);
 					ary.unshift(p);
 				});

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -566,11 +566,11 @@ DataTable.ext.buttons.excelHtml5 = {
                         if (value) {
                                 if (value.reverse) {
                                         value.forEach( function( v ) {
-                                                xml += '<c t="inlineStr"><is><t>' + v + '</t></is></c>';
+                                                xml += '<row><c t="inlineStr"><is><t>' + v + '</t></is></c></row>';
                                         } );
                                 }
                         } else {
-                                xml += '<c t="inlineStr"><is><t>' + value + '</t></is></c>';
+                                xml += '<row><c t="inlineStr"><is><t>' + value + '</t></is></c></row>';
                         }
                 };
 

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -320,8 +320,32 @@ var _exportData = function ( dt, config )
 	var footer = config.footer ? newLine+join( data.footer ) : '';
 	var body = [];
 
+	if (config.prefix) {
+		if (config.prefix.reverse) {
+			config.prefix.reverse().forEach(function(p) {
+				body.unshift(newLine);
+				body.unshift(p);
+			});
+		} else {
+			body.unshift(newLine);
+			body.unshift(config.prefix);
+		}
+	}
+
 	for ( var i=0, ien=data.body.length ; i<ien ; i++ ) {
 		body.push( join( data.body[i] ) );
+	}
+
+	if (config.suffix) {
+		if (config.suffix.forEach) {
+			config.suffix.forEach(function(s) {
+				body.push(newLine);
+				body.push(s);
+			});
+		} else {
+			body.push(newLine);
+			body.push(config.suffix);
+		}
 	}
 
 	return {
@@ -482,34 +506,8 @@ DataTable.ext.buttons.csvHtml5 = {
 		var newLine = _newLine( config );
 		var output = _exportData( dt, config ).str;
 
-		var ary = [ output ];
-
-		if (config.prefix) {
-			if (config.prefix.reverse) {
-				config.prefix.reverse().forEach(function(p) {
-					ary.unshift(newLine);
-					ary.unshift(p);
-				});
-			} else {
-				ary.unshift(newLine);
-				ary.unshift(config.prefix);
-			}
-		}
-
-		if (config.suffix) {
-			if (config.suffix.forEach) {
-				config.suffix.forEach(function(s) {
-					ary.push(newLine);
-					ary.push(s);
-				});
-			} else {
-				ary.push(newLine);
-				ary.push(config.suffix);
-			}
-		}
-
 		_saveAs(
-			new Blob( ary, {type : 'text/csv'} ),
+			new Blob( output, {type : 'text/csv'} ),
 			_filename( config )
 		);
 	},
@@ -566,6 +564,16 @@ DataTable.ext.buttons.excelHtml5 = {
 			return '<row>'+cells.join('')+'</row>';
 		};
 
+                if ( config.prefix ) {
+                        if (config.prefix.reverse) {
+                                config.prefix.forEach(function(p) {
+                                        xml += addRow(p)
+                                });
+                        } else {
+                                xml += addRow(config.prefix);
+                        }
+                }
+
 		if ( config.header ) {
 			xml += addRow( data.header );
 		}
@@ -577,6 +585,16 @@ DataTable.ext.buttons.excelHtml5 = {
 		if ( config.footer ) {
 			xml += addRow( data.footer );
 		}
+
+                if ( config.suffix ) {
+                        if (config.suffix.reverse) {
+                                config.suffix.forEach(function(p) {
+                                        xml += addRow(p);
+                                });
+                        } else {
+                                xml += addRow(config.suffix);
+                        }
+                }
 
 		var zip           = new window.JSZip();
 		var _rels         = zip.folder("_rels");
@@ -709,6 +727,38 @@ DataTable.ext.buttons.pdfHtml5 = {
 				margin: [ 0, 0, 0, 12 ]
 			} );
 		}
+
+                if ( config.prefix ) {
+                        if ( config.prefix.reverse ) {
+                                config.prefix.reverse.forEach( function(p) {
+                                        doc.content.unshift( {
+                                                text: p,
+                                                style: 'message'
+                                        } );
+                                } );
+                        } else {
+                                doc.content.unshift( {
+                                        text: config.prefix,
+                                        style: 'message'
+                                } );
+                        }
+                }
+
+                if ( config.suffix ) {
+                        if ( config.suffix.reverse ) {
+                                config.suffix.forEach( function(s) {
+                                        doc.content.push( {
+                                                text: s,
+                                                style: 'message'
+                                        } );
+                                } );
+                        } else {
+                                doc.content.push( {
+                                        text: config.suffix,
+                                        style: 'message'
+                                } );
+                        }
+                }
 
 		if ( config.customize ) {
 			config.customize( doc );

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -507,7 +507,7 @@ DataTable.ext.buttons.csvHtml5 = {
 		var output = _exportData( dt, config ).str;
 
 		_saveAs(
-			new Blob( output, {type : 'text/csv'} ),
+			new Blob( [ output ], {type : 'text/csv'} ),
 			_filename( config )
 		);
 	},

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -563,14 +563,16 @@ DataTable.ext.buttons.excelHtml5 = {
 		};
 
                 var addLines = function( value ) {
+                        var lpfx = '<row><c t="inlineStr"><is><t>';
+                        var lsfx = '</t></is></c></row>';
                         if (value) {
                                 if (value.reverse) {
                                         value.forEach( function( v ) {
-                                                xml += '<row><c t="inlineStr"><is><t>' + v + '</t></is></c></row>';
+                                                xml += lpfx + v + lsfx;
                                         } );
                                 }
                         } else {
-                                xml += '<row><c t="inlineStr"><is><t>' + value + '</t></is></c></row>';
+                                xml += lpfx + value + lsfx;
                         }
                 };
 

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -730,7 +730,7 @@ DataTable.ext.buttons.pdfHtml5 = {
 
                 if ( config.prefix ) {
                         if ( config.prefix.reverse ) {
-                                config.prefix.reverse.forEach( function(p) {
+                                config.prefix.reverse().forEach( function(p) {
                                         doc.content.unshift( {
                                                 text: p,
                                                 style: 'message'

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -565,18 +565,18 @@ DataTable.ext.buttons.excelHtml5 = {
                 var addLines = function( value ) {
                         var lpfx = '<row><c t="inlineStr"><is><t>';
                         var lsfx = '</t></is></c></row>';
-                        if (value) {
-                                if (value.reverse) {
-                                        value.forEach( function( v ) {
-                                                xml += lpfx + v + lsfx;
-                                        } );
-                                }
-                        } else {
-                                xml += lpfx + value + lsfx;
+			if (value) {
+				if (value.reverse) {
+					value.forEach( function( v ) {
+						xml += lpfx + v + lsfx;
+					} );
+				} else {
+				        xml += lpfx + value + lsfx;
+			        }
                         }
-                };
+		};
 
-                addLines(config.prefix);
+		addLines(config.prefix);
 
 		if ( config.header ) {
 			xml += addRow( data.header );

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -482,8 +482,34 @@ DataTable.ext.buttons.csvHtml5 = {
 		var newLine = _newLine( config );
 		var output = _exportData( dt, config ).str;
 
+		var ary = [ output ];
+
+		if (config.prefix) {
+			if (config.prefix.reverse) {
+				config.prefix.reverse().forEach(function(p) {
+					ary.unshift(newLine);
+					ary.unshift(p);
+				});
+			} else {
+				ary.unshift(newLine);
+				ary.unshift(config.prefix);
+			}
+		}
+
+		if (config.suffix) {
+			if (config.suffix.forEach) {
+				config.suffix.forEach(function(s) {
+					ary.push(newLine);
+					ary.push(s);
+				});
+			} else {
+				ary.push(newLine);
+				ary.push(config.suffix);
+			}
+		}
+
 		_saveAs(
-			new Blob( [output], {type : 'text/csv'} ),
+			new Blob( ary, {type : 'text/csv'} ),
 			_filename( config )
 		);
 	},
@@ -500,7 +526,11 @@ DataTable.ext.buttons.csvHtml5 = {
 
 	header: true,
 
-	footer: false
+	footer: false,
+
+	prefix: null,
+
+	suffix: null
 };
 
 //


### PR DESCRIPTION
Our customer requires additional lines of text before and after the CSV output, this patch adds 'suffix' and 'prefix' options that can take either a single string, or an array of strings, and add them to the output.  You can see it working [at this JS Fiddle](http://jsfiddle.net/edwinw/hxfz6aLq/1/).  Released under the original source's license (MIT).