### PR TITLE
Updated to allow users to customize column headers when exporting.

### DIFF
--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -1405,10 +1405,10 @@ var _exportData = function ( dt, inOpts )
 		return str;
 	};
 
-	var header = config.columnHeaders( dt.columns( config.columns ).indexes().map( function (idx, i) {
+	var header = dt.columns( config.columns ).indexes().map( function (idx, i) {
 		var title = strip( dt.column( idx ).header().innerHTML );
 		return config.columnHeaders( idx, title, dt.column( idx ) ) ;
-	} ).toArray() );
+	} ).toArray();
 
 	var footer = dt.table().footer() ?
 		dt.columns( config.columns ).indexes().map( function (idx, i) {

--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -1374,6 +1374,7 @@ var _exportData = function ( dt, inOpts )
 	var config = $.extend( true, {}, {
 		rows:          null,
 		columns:       '',
+		columnHeaders: function( header ) { return header; },
 		modifier:      {
 			search: 'applied',
 			order:  'applied'
@@ -1404,9 +1405,9 @@ var _exportData = function ( dt, inOpts )
 		return str;
 	};
 
-	var header = dt.columns( config.columns ).indexes().map( function (idx, i) {
+	var header = config.columnHeaders( dt.columns( config.columns ).indexes().map( function (idx, i) {
 		return strip( dt.column( idx ).header().innerHTML );
-	} ).toArray();
+	} ).toArray() );
 
 	var footer = dt.table().footer() ?
 		dt.columns( config.columns ).indexes().map( function (idx, i) {

--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -1374,7 +1374,7 @@ var _exportData = function ( dt, inOpts )
 	var config = $.extend( true, {}, {
 		rows:          null,
 		columns:       '',
-		columnHeaders: function( header ) { return header; },
+		columnHeaders: function( colnum, title, column ) { return title; },
 		modifier:      {
 			search: 'applied',
 			order:  'applied'
@@ -1406,14 +1406,15 @@ var _exportData = function ( dt, inOpts )
 	};
 
 	var header = config.columnHeaders( dt.columns( config.columns ).indexes().map( function (idx, i) {
-		return strip( dt.column( idx ).header().innerHTML );
+		var title = strip( dt.column( idx ).header().innerHTML );
+		return config.columnHeaders( idx, title, dt.column( idx ) ) ;
 	} ).toArray() );
 
 	var footer = dt.table().footer() ?
 		dt.columns( config.columns ).indexes().map( function (idx, i) {
 			var el = dt.column( idx ).footer();
 			return el ?
-				strip( el.innerHTML ) :
+				config.columnHeaders(idx, strip( el.innerHTML ), dt.column( idx ) ) :
 				'';
 		} ).toArray() :
 		null;


### PR DESCRIPTION
I have been playing around with the export features today, and I came up with several minor improvements which I think enhance the functionality of the buttons export feature by allowing users to customized how both the data and the headers are exported.  

The first change I recommend(but am not submitting as part of this request) is to change the default orthogonal type from 'display' to 'export' and add a note to the documentation that the buttons function extends the orthogonal types used by the ColumnDefs render so that people can pre-process the data with special formatting, characters, etc when exporting the data.

Secondly, and this is where my new pull request fits in. It would be nice to also be able to customize the column headers when exporting the data.  Currently the export function just uses the existing column headers which are shown on the table when exporting.  This pull request adds a configuration option to the exportOptions called "columnHeaders" which defaults to the current setup and just returns the column headers, but which can be configured by passing a function which will receive the existing column headers and which can then return a processed version of the headers.  This is useful for internationalization where you want to change the language used in the titles, as well as when you are exporting data which needs to be formatted in a particular way for another application to properly read it.