### PR TITLE
Fix button selector by name

### DIFF
--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -955,7 +955,7 @@ Buttons.buttonSelector = function ( insts, selector )
 			if ( v !== null ) {
 				buttons.push( {
 					node: v.node[0],
-					name: v.name
+					name: v.conf.name
 				} );
 			}
 		} );
@@ -965,7 +965,7 @@ Buttons.buttonSelector = function ( insts, selector )
 				if ( w !== null ) {
 					buttons.push( {
 						node: w.node[0],
-						name: w.name
+						name: w.conf.name
 					} );
 				}
 			} );


### PR DESCRIPTION
Hi, I've found a bug in the current version 1.0.3 of the Buttons extension. Among the various button selectors, the selector by name (using the `:name` suffix) does not work. Another user [posted this bug and a possible solution](https://www.datatables.net/forums/discussion/30257/button-selector-by-name-doesn-t-work-in-buttons-fix-included) to the free community support forum in September, but it has been overlooked since then, obviously. That's why I'm making this pull request now hoping that it will be integrated soon because I can confirm that the other user's proposed code change fixes the problem.