### PR TITLE
New: Implement colvis.label and colvis.stateChange options 

### DIFF
--- a/docs/button/colvis.xml
+++ b/docs/button/colvis.xml
@@ -30,6 +30,9 @@
 		Columns selector that defines the columns to include in the column visibility button set. By default this is `-type undefined` which results in all columns being selected, but any of the `-type column-selector` options can be used to define a custom button set.
 	</option>
 
+	<option type="function" name="label" default="undefined">
+        Callback function to compute the label displayed for each column button.
+	</option>
 
 	<example title="DataTables initialisation: Show the `colvis` button with default options"><![CDATA[
 

--- a/examples/column_visibility/label.xml
+++ b/examples/column_visibility/label.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dt-example table-type="html" order="5">
+
+<css lib="datatables buttons" />
+<js lib="jquery datatables buttons buttons-colvis">
+<![CDATA[
+$(document).ready(function() {
+	$('#example').DataTable( {
+		dom: 'Bfrtip',
+		buttons: [
+			{
+				extend: 'colvis',
+				label: function ( index, title ) {
+					return (index+1) +'. '+ title;
+				}
+			}
+		]
+	} );
+} );
+]]>
+</js>
+
+<title lib="Buttons">Select column labels</title>
+
+<info><![CDATA[
+
+The `b-button colvis` button type provides a `label` option to allow you to change the name of each column label in the column visibility control list. This option is a callback taking the column index and default title as parameters and returning the label to use..
+
+]]></info>
+
+</dt-example>

--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -48,7 +48,8 @@ $.extend( DataTable.ext.buttons, {
 			className: 'buttons-colvis',
 			buttons: [ {
 				extend: 'columnsToggle',
-				columns: conf.columns
+				columns: conf.columns,
+				labelFormatter: conf.label
 			} ]
 		};
 	},
@@ -58,7 +59,8 @@ $.extend( DataTable.ext.buttons, {
 		var columns = dt.columns( conf.columns ).indexes().map( function ( idx ) {
 			return {
 				extend: 'columnToggle',
-				columns: idx
+				columns: idx,
+				labelFormatter: conf.labelFormatter
 			};
 		} ).toArray();
 
@@ -69,7 +71,8 @@ $.extend( DataTable.ext.buttons, {
 	columnToggle: function ( dt, conf ) {
 		return {
 			extend: 'columnVisibility',
-			columns: conf.columns
+			columns: conf.columns,
+			labelFormatter: conf.labelFormatter
 		};
 	},
 
@@ -79,7 +82,8 @@ $.extend( DataTable.ext.buttons, {
 			return {
 				extend: 'columnVisibility',
 				columns: idx,
-				visibility: conf.visibility
+				visibility: conf.visibility,
+				labelFormatter: conf.labelFormatter
 			};
 		} ).toArray();
 
@@ -90,7 +94,12 @@ $.extend( DataTable.ext.buttons, {
 	columnVisibility: {
 		columns: undefined, // column selector
 		text: function ( dt, button, conf ) {
-			return conf._columnText( dt, conf.columns );
+			var columnLabel = conf._columnText( dt, conf.columns );
+			if (typeof(conf.labelFormatter) !== 'undefined') {
+				 var idx = dt.column( conf.columns ).index();
+				 columnLabel = conf.labelFormatter(idx, columnLabel);
+			}
+			return columnLabel;
 		},
 		className: 'buttons-columnVisibility',
 		action: function ( e, dt, button, conf ) {


### PR DESCRIPTION
Hello,
those are 2 options I used to have with DataTables ColVis extension that I missed in the Buttons.colvis implementation.
- label:    Allows customisation of the labels used for the buttons.
- stateChange:  Callback function to let you know when the state has changed.

Cf: https://datatables.net/extensions/colvis/options

Not sure if it was the right way to do this but it fixed my issue for now...
