### PR TITLE
Fix: Specify auto width of columns

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -1272,6 +1272,9 @@ DataTable.ext.buttons.pdfHtml5 = {
 				{
 					table: {
 						headerRows: 1,
+						widths: $.map( data.header, function ( d ) {
+							return '*';
+						}),
 						body: rows
 					},
 					layout: 'noBorders'


### PR DESCRIPTION
Without it, columns have minimal widths. To use full width of pages, pass `*` for each column.

Note that this is the default behavior of flash pdf export by (legacy) TableTools I'm using.

[ref: pdfmake README](https://github.com/bpampuch/pdfmake#tables)
