### PR TITLE
FIX: Check if the DataTable is destroying before activating the column

### DIFF
--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -108,7 +108,7 @@ $.extend( DataTable.ext.buttons, {
 
 			dt
 				.on( 'column-visibility.dt'+conf.namespace, function (e, settings, column, state) {
-					if ( column === conf.columns ) {
+					if ( ! settings.bDestroying && column === conf.columns ) {
 						that.active( state );
 					}
 				} )


### PR DESCRIPTION
The issue: if I've added a button after init using `dt.button().add(index, obj)`, and there is a column hidden using colVis when I attempt to destroy the DatatTable instance via `dt.destroy()`, I get a Javascript error.

Example of error: https://jsfiddle.net/jpobley/wgofyfxx/15/
 
This error does not occur if a button has not been added after init using the method explained above. It is also important to note that I'm attempting to destroy the instance only using `dt.destroy()`, not the instance _and_ the table node using `dt.destroy(true)`. This error does not occur when passing `true`.

Example with fix from this PR: https://jsfiddle.net/jpobley/wgofyfxx/14/

The issue is the when the DT instance is destroyed, it makes all invisible columns visible, which attempts to activate a column's button. By the time that happens, though, the buttons aren't available anymore. I'm not convinced that my proposed fix is the correct solution, but I have stepped through the `dataTables.buttons.js` code and don't seen any thing that sticks out as the reason for this issue.

Please advise if there is somewhere/something else I should be fixing.

This PR is offered under the project's existing license (MIT)