### PR TITLE
Customize Data Before Export; HTML5 & Flash Buttons (e.g, copy, CSV, Excel, PDF) and Print button

### DIFF
--- a/js/buttons.flash.js
+++ b/js/buttons.flash.js
@@ -722,7 +722,7 @@ DataTable.ext.buttons.copyFlash = $.extend( {}, flashButton, {
 		var flash = config._flash;
 		var data = _exportData( dt, config );
 		var output = config.customize ?
-			config.customize( data.str, config ) :
+			config.customize( data.str, config, data ) :
 			data.str;
 
 		flash.setAction( 'copy' );
@@ -756,7 +756,7 @@ DataTable.ext.buttons.csvFlash = $.extend( {}, flashButton, {
 		var flash = config._flash;
 		var data = _exportData( dt, config );
 		var output = config.customize ?
-			config.customize( data.str, config ) :
+			config.customize( data.str, config, data ) :
 			data.str;
 
 		flash.setAction( 'csv' );
@@ -780,6 +780,11 @@ DataTable.ext.buttons.excelFlash = $.extend( {}, flashButton, {
 		var xml = '';
 		var flash = config._flash;
 		var data = dt.buttons.exportData( config.exportOptions );
+
+		if ( config.customizeData ){
+			data = config.customizeData( data, config, button );
+		}
+
 		var addRow = function ( row ) {
 			var cells = [];
 
@@ -839,6 +844,11 @@ DataTable.ext.buttons.pdfFlash = $.extend( {}, flashButton, {
 		// Set the text
 		var flash = config._flash;
 		var data = dt.buttons.exportData( config.exportOptions );
+
+		if ( config.customizeData ){
+			data = config.customizeData( data, config, button );
+		}
+
 		var totalWidth = dt.table().node().offsetWidth;
 
 		// Calculate the column width ratios for layout of the table in the PDF

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -490,7 +490,7 @@ DataTable.ext.buttons.copyHtml5 = {
 			} );
 
 		if ( config.customize ) {
-			output = config.customize( output, config );
+			output = config.customize( output, config, exportData );
 		}
 
 		var textarea = $('<textarea readonly/>')
@@ -583,11 +583,12 @@ DataTable.ext.buttons.csvHtml5 = {
 	action: function ( e, dt, button, config ) {
 		// Set the text
 		var newLine = _newLine( config );
-		var output = _exportData( dt, config ).str;
+		var exportData = _exportData( dt, config );
+		var output = exportData.str;
 		var charset = config.charset;
 
 		if ( config.customize ) {
-			output = config.customize( output, config );
+			output = config.customize( output, config, exportdata );
 		}
 
 		if ( charset !== false ) {
@@ -732,6 +733,10 @@ DataTable.ext.buttons.pdfHtml5 = {
 		var newLine = _newLine( config );
 		var data = dt.buttons.exportData( config.exportOptions );
 		var rows = [];
+
+		if ( config.customizeData ){
+			data = config.customizeData( data, button, config );
+		}
 
 		if ( config.header ) {
 			rows.push( $.map( data.header, function ( d ) {

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -735,7 +735,7 @@ DataTable.ext.buttons.pdfHtml5 = {
 		var rows = [];
 
 		if ( config.customizeData ){
-			data = config.customizeData( data, button, config );
+			data = config.customizeData( data, config, button );
 		}
 
 		if ( config.header ) {

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -647,6 +647,11 @@ DataTable.ext.buttons.excelHtml5 = {
 		// Set the text
 		var xml = '';
 		var data = dt.buttons.exportData( config.exportOptions );
+
+		if ( config.customizeData ){
+			data = config.customizeData( data, config, button );
+		}
+
 		var addRow = function ( row ) {
 			var cells = [];
 

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -588,7 +588,7 @@ DataTable.ext.buttons.csvHtml5 = {
 		var charset = config.charset;
 
 		if ( config.customize ) {
-			output = config.customize( output, config, exportdata );
+			output = config.customize( output, config, exportData );
 		}
 
 		if ( charset !== false ) {

--- a/js/buttons.print.js
+++ b/js/buttons.print.js
@@ -75,7 +75,12 @@ DataTable.ext.buttons.print = {
 	},
 
 	action: function ( e, dt, button, config ) {
-		var data = dt.buttons.exportData( config.exportOptions );
+		var data = dt.buttons.exportData( config.exportOptions );		
+
+		if ( config.customizeData ) {
+			data = config.customizeData( data, button, config );
+		}
+		
 		var addRow = function ( d, tag ) {
 			var str = '<tr>';
 

--- a/js/buttons.print.js
+++ b/js/buttons.print.js
@@ -78,7 +78,7 @@ DataTable.ext.buttons.print = {
 		var data = dt.buttons.exportData( config.exportOptions );		
 
 		if ( config.customizeData ) {
-			data = config.customizeData( data, button, config );
+			data = config.customizeData( data, config, button );
 		}
 		
 		var addRow = function ( d, tag ) {


### PR DESCRIPTION
I posed a question here: http://datatables.net/forums/discussion/comment/89936

This talked about how the whole data set could not be customized before output, only formatted row-by-row, excluding the possibility of dynamic subtotals.  

A person could create their own buttons, but sometimes they may not want to deal with the MIME types, etc.

Please refer to the commit log, and see here for an example of all the buttons working:
http://live.datatables.net/sajaxota/6/edit?js,output
