### PR TITLE
Ensure that html stripping works with html code containing linebreaks

### DIFF
--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -1544,7 +1544,7 @@ var _exportData = function ( dt, inOpts )
 		}
 
 		if ( config.stripHtml ) {
-			str = str.replace( /<.*?>/g, '' );
+			str = str.replace( /<[^>]*>/g, '' );
 		}
 
 		if ( config.trim ) {


### PR DESCRIPTION
Hi!

I recently had a problem with the removal of html code when exporting table contents with html5 buttons.
For some reason the regular expression used to detect html tags fails when an attribute contains linebreaks (which seems to be legit when using multiline tooltips - https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute).

Please take a look at https://jsfiddle.net/x5tdnt7k/3/ and check the generated csv output.

I've adopted the regular expression which seems to resolve the issue.
However, I haven't found out yet why exactly this change solves the problem (all the regular expression documentations I checked indicate that both versions of the regex should behave identically).




In case you want to merge this pull request:
I acknowledge that this contribution is offered under and will be made available under the project's existing license.