### PR TITLE
buttons.colVis.js - fix for nested tables

### DIFF
--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -108,7 +108,7 @@ $.extend( DataTable.ext.buttons, {
 
 			dt
 				.on( 'column-visibility.dt'+conf.namespace, function (e, settings, column, state) {
-					if ( ! settings.bDestroying && column === conf.columns ) {
+					if ( ! settings.bDestroying && column === conf.columns && settings.sTableId == dt.settings()[0].sTableId ) {
 						that.active( state );
 					}
 				} )

--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -108,7 +108,7 @@ $.extend( DataTable.ext.buttons, {
 
 			dt
 				.on( 'column-visibility.dt'+conf.namespace, function (e, settings, column, state) {
-					if ( ! settings.bDestroying && column === conf.columns && settings.sTableId == dt.settings()[0].sTableId ) {
+					if ( ! settings.bDestroying && column === conf.columns && settings.nTable == dt.settings()[0].nTable ) {
 						that.active( state );
 					}
 				} )


### PR DESCRIPTION
Hi,
This PR concerns problem with colVis for nested tables. Here how it looks for me.
![zaznaczenie_018](https://cloud.githubusercontent.com/assets/7151921/15075814/9b8cb8be-13a6-11e6-8647-91f7f4859437.png)
The problem was when I've selected columns for nested table, columns were enabled/disabled properly, only for that one. But buttons collection (menu) was changed incorrectly (parent table buttons menu was also changed).
That change works for me and hope, not break anything.
If there is different way to solve my problem, please let me know.
