### PR TITLE
Bug Fix: Detect copy success, fall back to CTRL+C on failure

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -864,21 +864,22 @@ DataTable.ext.buttons.copyHtml5 = {
 			textarea[0].focus();
 			textarea[0].select();
 
-			try {
-				document.execCommand( 'copy' );
-				hiddenDiv.remove();
+		try {
+			var successful = document.execCommand( 'copy' );
+			hiddenDiv.remove();
 
+			if (successful) {
 				dt.buttons.info(
 					dt.i18n( 'buttons.copyTitle', 'Copy to clipboard' ),
 					dt.i18n( 'buttons.copySuccess', {
-							1: "Copied one row to clipboard",
-							_: "Copied %d rows to clipboard"
-						}, exportData.rows ),
+						1: 'Copied one row to clipboard',
+						_: 'Copied %d rows to clipboard'
+					}, exportData.rows ),
 					2000
 				);
-
 				return;
 			}
+		}
 			catch (t) {}
 		}
 

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -864,22 +864,22 @@ DataTable.ext.buttons.copyHtml5 = {
 			textarea[0].focus();
 			textarea[0].select();
 
-		try {
-			var successful = document.execCommand( 'copy' );
-			hiddenDiv.remove();
+			try {
+				var successful = document.execCommand( 'copy' );
+				hiddenDiv.remove();
 
-			if (successful) {
-				dt.buttons.info(
-					dt.i18n( 'buttons.copyTitle', 'Copy to clipboard' ),
-					dt.i18n( 'buttons.copySuccess', {
-						1: 'Copied one row to clipboard',
-						_: 'Copied %d rows to clipboard'
-					}, exportData.rows ),
-					2000
-				);
-				return;
+				if (successful) {
+					dt.buttons.info(
+						dt.i18n( 'buttons.copyTitle', 'Copy to clipboard' ),
+						dt.i18n( 'buttons.copySuccess', {
+							1: 'Copied one row to clipboard',
+							_: 'Copied %d rows to clipboard'
+						}, exportData.rows ),
+						2000
+					);
+					return;
+				}
 			}
-		}
 			catch (t) {}
 		}
 


### PR DESCRIPTION
Details: https://datatables.net/forums/discussion/35471/buttons-is-there-a-size-limit-for-copy

TL;DR: `document.execCommand('copy')` will fail silently if the data being copied to the clipboard is too large (we're talking a couple hundred KB in some cases), unless you check its boolean return value to determine success.