### PR TITLE
Take line breaks into account when calculating column widths

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -603,16 +603,25 @@ function _createNode( doc, nodeName, opts ) {
  * @param  {int}    col  Column index
  * @return {int}         Column width
  */
-function _excelColWidth( data, col ) {
+function _excelColWidth( data, col, config ) {
 	var max = data.header[col].length;
 	var len;
+	var newLine = ( _newLine( config ) == '\r\n' ? 'win' : 'other' );
+	var cellData, testNL, splitCell;
 
 	if ( data.footer && data.footer[col].length > max ) {
 		max = data.footer[col].length;
 	}
 
 	for ( var i=0, ien=data.body.length ; i<ien ; i++ ) {
-		len = data.body[i][col].toString().length;
+		cellData = data.body[i][col].toString();
+		testNL = ( newLine == 'win' ? cellData.match(/[\r\n]/g) : cellData.match(/[\n]/g) );
+		if ( testNL ) {
+			splitCell = ( (testNL && newLine == 'win') ? cellData.split(/[\r\n]/g) : cellData.split(/[\n]/g) );
+			len = Math.max.apply(Math, $.map(splitCell, function (el) { return el.length })) * 1.2;
+		} else {
+			len = (cellData.length * 1.2);
+		}
 
 		if ( len > max ) {
 			max = len;
@@ -625,7 +634,7 @@ function _excelColWidth( data, col ) {
 	}
 
 	// And a min width
-	return max > 5 ? max : 5;
+	return max > 8 ? max : 8;
 }
 
 // Excel - Pre-defined strings to build a basic XLSX file
@@ -1148,7 +1157,8 @@ DataTable.ext.buttons.excelHtml5 = {
 				attr: {
 					min: i+1,
 					max: i+1,
-					width: _excelColWidth( data, i ),
+					width: _excelColWidth( data, i, config ),
+					bestFit: 1,
 					customWidth: 1
 				}
 			} ) );


### PR DESCRIPTION
When line breaks ( html br tag) are present in a cell, for example column 1 - product item, column 2 - multiple partnumbers (each around 16 characters), it's easy to convert them to text line breaks. For example:
```js
format: {
	body: function( data, row, column, node){
		if(data.match(/&lt;br\s*\/?&gt;/gmi)){
			//FOR IE, other browsers data.replace(/&lt;br\s*\/?&gt;/gmi, '\n'); ???
			return data.replace(/&lt;br&gt;/gmi, '\r\n');
		} else {
			//Strip html tags from data content
			return data.replace(/&lt;\/?[^&gt;]+(&gt;|$)/gmi, '');
		}
```
At the moment the calculation of the column width doesn't take these line breaks into account and in my example case will often create columns with width 40 and displaying them all in one line without separation. With the addition of the new styles in version 1.2.2 , one could apply the wrap text style and with this pull request the column width would be calculated and displayed correctly (through the bestFit=1 attribute added on line 1161).
Added config as parameter to internal function _excelColWidth for automatic detection of OS platform. Reason: decide which regex to apply (line 609, 618 and 620).
Slightly increased the len value by multiplying with 1.2 for aesthetic reasons (line 621 and 623). Adds a little more space.
Set default value to 8 instead of 5 (line 637), as it compares better to the standard value used by excel.