### PR TITLE
Fix: null, undefined and blank cell in excel export

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -1069,8 +1069,9 @@ DataTable.ext.buttons.excelHtml5 = {
 				var cellId = createCellPos(i) + '' + currentRow;
 				var cell;
 
-				if ( row[i] === null || row[i] === undefined ) {
-					row[i] = '';
+				// For null, undefined of blank cell, continue so it doesn't create the _createNode
+				if ( row[i] === null || row[i] === undefined || row[i] == '' ) {
+					continue;
 				}
 
 				// Detect numbers - don't match numbers with leading zeros or a negative


### PR DESCRIPTION
Hi everyone!

I've found a problem while exporting to excel and have a blank string or null values.
When I open the xlsx file, it creates this tag:

```
<c t="inlineStr" r="D2">
  <is>
    <t/>
  </is>
</c>
```

This D2 cell is blank. But when I try to use the COUNTBLANK function on excel, this cell is counted and it shouldn't. It's like this D2 cell has some value..
And when I delete the cell on excel and open the xml again, this whole tag is deleted. So, the excel only identifies blank/null cell when it does not have this cell hierarchy.