### PR TITLE
Modify regex to be correct and more efficient.

### DIFF
--- a/js/buttons.flash.js
+++ b/js/buttons.flash.js
@@ -856,7 +856,7 @@ function _xlsxToStrings( obj ) {
 
 			// Safari, IE and Edge will put empty name space attributes onto
 			// various elements making them useless. This strips them out
-			str = str.replace( /<(.*?) xmlns=""(.*?)>/g, '<$1 $2>' );
+			str = str.replace( /<([^<>]*?) xmlns=""([^<>]*?)>/g, '<$1 $2>' );
 
 			obj[ name ] = str;
 		}

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -473,7 +473,7 @@ function _addToZip( zip, obj ) {
 
 			// Safari, IE and Edge will put empty name space attributes onto
 			// various elements making them useless. This strips them out
-			str = str.replace( /<(.*?) xmlns=""(.*?)>/g, '<$1 $2>' );
+			str = str.replace( /<([^<>]*?) xmlns=""([^<>]*?)>/g, '<$1 $2>' );
 
 			zip.file( name, str );
 		}


### PR DESCRIPTION
There are a couple of issues with the <(.*?) xmlns=""(.*?)> expression.  The first is that it will actually capture ' xmlns=""' inside the text of an XML element.  This can be seen here: https://regex101.com/r/OlyTWe/2

The second issue is that in Chrome, this string doesn't exist unless it was in the table data.  This means that the first capture group captures the entire XML string character by character.  This causes a serious hit to performance.

I have rewritten the expression so that it should in almost all cases only match the string when it is an attribute inside of a tag.  This also reduces the amount of text captured in the first group and markedly improves performance when exporting thousands of rows in Chrome.  An example of the new expression working on the same string from the previous example can be seen here: https://regex101.com/r/eTycqr/2.

This has been tested in Chrome, IE, and Edge.  I would welcome my code being used under the MIT license.