### PR TITLE
allow printing complex header with rowspan and colspan

### DIFF
--- a/js/buttons.print.js
+++ b/js/buttons.print.js
@@ -102,7 +102,26 @@ DataTable.ext.buttons.print = {
 		var html = '<table class="'+dt.table().node().className+'">';
 
 		if ( config.header ) {
-			html += '<thead>'+ addRow( data.header, 'th' ) +'</thead>';
+			// Get table header from table API
+			var thead = $( dt.table().header() );
+			// Construct new thead element
+			var new_thead = $( '<thead>' );
+			// map tr from datatable header, append to new_thead
+			thead.find( 'tr' ).map( function () {
+				// Construct new tr element
+				var new_tr = $( '<tr>' );
+				// map th from datatable header, append to new_tr
+				$( this ).find( 'th' ).map( function () {
+					// construct new th element then set rowspan and colspan from existing
+					var $th = $( this );
+					return $( '<th>' ).attr( {
+						'colspan': $th.attr( 'colspan' ),
+						'rowspan': $th.attr( 'rowspan' )
+					} ).text( $th.text() )[0];
+				} ).appendTo( new_tr );
+				return new_tr[0];
+			} ).appendTo( new_thead );
+			html += '<thead>' + new_thead.html() + '</thead>';
 		}
 
 		html += '<tbody>';


### PR DESCRIPTION
This pull request handle table with complex header that have `rowspan` and `colspan`. I'm using table API to get the table header, then create new element on the fly, set the `colspan` and `rowspan` same as the header in datatable, then use this for printing.

My first attempt is to clone the header and remove the attributes except `colspan` and `rowspan`. But I think, creating completely new `th` and only set `colspan` and `rowspan` from original datatables will be better, because it could be a lot of attributes that can be set by datatables in the future. Creating new element will make sure the `th` for printing only have `colspan` and `rowspan` attributes.

Demo:
Existing print without complex header support
https://jsfiddle.net/donnykurnia/qyp93yhc/

Print with complex header support
https://jsfiddle.net/donnykurnia/bw0r56a2/2/

Related discussion:
1. https://datatables.net/forums/discussion/29745/multiple-row-headers-export-in-pdf-excel-or-print#latest
2. https://datatables.net/forums/discussion/36666/print-two-headers#latest
3. https://github.com/DataTables/Buttons/issues/60

I acknowledge that my contribution is offered under and will be made available under the project's existing license (MIT).
