### PR TITLE
Fix: csvHtml5 exported file was missing the filename

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -919,7 +919,7 @@ DataTable.ext.buttons.csvHtml5 = {
 
 		// Set the text
 		var output = _exportData( dt, config ).str;
-		var info = dt.buttons.exportInfo();
+		var info = dt.buttons.exportInfo(config);
 		var charset = config.charset;
 
 		if ( config.customize ) {


### PR DESCRIPTION
There was a 'config' parameter missing on the exportInfo() function that prevented csv files to be exported with the correct filename.