### PR TITLE
added new regexp for formatting header names in dropdown menu

### DIFF
--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -148,6 +148,7 @@ $.extend( DataTable.ext.buttons, {
 			var idx = dt.column( conf.columns ).index();
 			var title = dt.settings()[0].aoColumns[ idx ].sTitle
 				.replace(/\n/g," ")        // remove new lines
+				.replace(/<br\s*\/?>/gi, " ")  // replace line breaks with spaces
 				.replace( /<.*?>/g, "" )   // strip HTML
 				.replace(/^\s+|\s+$/g,""); // trim
 


### PR DESCRIPTION
​I've encountered an issue with formatting column names in show/hide button dropdown menu.
When I separated words with 'br' tag in column header, there was no space between them in dropdown menu.
Here is the additional regexp that solves this.

![screenshot](https://user-images.githubusercontent.com/18448852/29654023-d34e4e86-88ab-11e7-8d7f-c13143c4db7b.png)

