### PR TITLE
Ignore download option

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -1354,6 +1354,10 @@ DataTable.ext.buttons.pdfHtml5 = {
 
 		var pdf = _pdfMake().createPdf( doc );
 
+		if ( config.ignoreDownload ) {
+        		this.processing( false );
+      		}
+      		else
 		if ( config.download === 'open' && ! _isDuffSafari() ) {
 			pdf.open();
 			this.processing( false );
@@ -1390,7 +1394,9 @@ DataTable.ext.buttons.pdfHtml5 = {
 
 	customize: null,
 
-	download: 'download'
+	download: 'download',
+	
+	ignoreDownload: false
 };
 
 


### PR DESCRIPTION
In my current case, I need to disable "download" option. I need only PDF document JSON and don't need to open PDF or download it. 
Your current options work in mode "download"/"open" only.
After my change everyone may use this construction:
```
{
  extend: 'pdfHtml5',
  footer: true,
  ignoreDownload: true,
  download: 'open',
  customize: function (doc) {
    //My processing doc JSON
  }
}
```