### PR TITLE
Add vs concatenate merged cells count

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -1129,7 +1129,7 @@ DataTable.ext.buttons.excelHtml5 = {
 					ref: 'A'+row+':'+createCellPos(colspan)+row
 				}
 			} ) );
-			mergeCells.attr( 'count', mergeCells.attr( 'count' )+1 );
+			mergeCells.attr( 'count', parseFloat(mergeCells.attr( 'count' ))+1 );
 			$('row:eq('+(row-1)+') c', rels).attr( 's', '51' ); // centre
 		};
 


### PR DESCRIPTION
When working with Buttons, I noticed that the merged cells count was being concatenated instead of added.
![buttons html5 js bug example](https://user-images.githubusercontent.com/30675027/32419452-9bc9aad2-c23f-11e7-88c3-4ee8dde59c3c.png)
I checked out my coding changes, and this is what I got:
![buttons fix](https://user-images.githubusercontent.com/30675027/32419454-a53026aa-c23f-11e7-8f99-7e007df6fa35.png)
