### PR TITLE
Collection dropup property

### DIFF
--- a/docs/button/collection.xml
+++ b/docs/button/collection.xml
@@ -62,6 +62,10 @@
 	<option type="integer" name="fade" default="400">
 		Animation speed that the collection is faded in and out of the display. This is an integer value that represents the animation duration in milliseconds. For no animation use the value `0`.
 	</option>
+	
+	<option type="boolean" name="dropup" default="false">
+		When `true`, the dropdown collection always drops up. When `false`, the collection drops down or up depending on the available overflow.
+	</option>
 
 
 	<example title="DataTables initialisation: Create an export collection"><![CDATA[

--- a/js/buttons.print.js
+++ b/js/buttons.print.js
@@ -157,13 +157,22 @@ DataTable.ext.buttons.print = {
 			config.customize( win, config, dt );
 		}
 
-		// Allow stylesheets time to load
-		win.setTimeout( function () {
-			if ( config.autoPrint ) {
-				win.print(); // blocking - so close will not
-				win.close(); // execute until this is done
+		// autoPrint calls the print dialog when the new window is ready and fully rendered
+		if ( config.autoPrint ) {
+			// This function is to be injected within the new window
+			function doPrint() {
+				// Allow stylesheets time to load
+				setTimeout( function () {
+					window.print(); // blocking - so close will not
+					window.close(); // execute until this is done
+				}, 1000 );
 			}
-		}, 1000 );
+			// include the script directly in the new window's body.onload event
+			// This way, it will be run within the newly created window instead of the current window
+			var script = win.document.createElement('script');
+			script.innerHTML = 'document.body.onload = ' + doPrint.toString();
+			win.document.body.appendChild(script);
+	    	}
 	},
 
 	title: '*',

--- a/js/buttons.print.js
+++ b/js/buttons.print.js
@@ -157,22 +157,13 @@ DataTable.ext.buttons.print = {
 			config.customize( win, config, dt );
 		}
 
-		// autoPrint calls the print dialog when the new window is ready and fully rendered
-		if ( config.autoPrint ) {
-			// This function is to be injected within the new window
-			function doPrint() {
-				// Allow stylesheets time to load
-				setTimeout( function () {
-					window.print(); // blocking - so close will not
-					window.close(); // execute until this is done
-				}, 1000 );
+		// Allow stylesheets time to load
+		win.setTimeout( function () {
+			if ( config.autoPrint ) {
+				win.print(); // blocking - so close will not
+				win.close(); // execute until this is done
 			}
-			// include the script directly in the new window's body.onload event
-			// This way, it will be run within the newly created window instead of the current window
-			var script = win.document.createElement('script');
-			script.innerHTML = 'document.body.onload = ' + doPrint.toString();
-			win.document.body.appendChild(script);
-	    	}
+		}, 1000 );
 	},
 
 	title: '*',

--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -1209,8 +1209,8 @@ $.extend( _dtButtons, {
 				var tableTop = tableContainer.offset().top;
 				var topOverflow = tableTop - listTop;
 				
-				// if bottom overflow is larger, move to the top because it fits better
-				if (bottomOverflow > topOverflow) {
+				// if bottom overflow is larger, move to the top because it fits better, or if dropup is requested
+				if (bottomOverflow > topOverflow || config.dropup) {
 					config._collection.css( 'top', hostPosition.top - config._collection.outerHeight() - 5);
 				}
 


### PR DESCRIPTION
Hi Allan, 

A property to force a collection to "drop up". If not set or set to false, it falls back to the default behaviour. Like Bootstrap's "dropup" class.

NB: When I set the buttons to show in table footer, a collection button was always dropping down, even when it would have been visually better to drop up (for instance, half of the collection was going overflow and required the user to scroll to click on a button). Maybe it's the way the overflows are calculated that needs to be improved... (?)

Don't know if it's a valuable PR for you... 
Thanks