### PR TITLE
Added option for repeating head in print.

### DIFF
--- a/js/buttons.print.js
+++ b/js/buttons.print.js
@@ -120,9 +120,24 @@ DataTable.ext.buttons.print = {
 		// Construct a table for printing
 		var html = '<table class="'+dt.table().node().className+'">';
 
-		if ( config.header ) {
-			html += '<thead>'+ addRow( data.header, 'th' ) +'</thead>';
+		html += '<thead>';
+		
+		// Adding logo to the page (repeats for every page while print)
+		if(config.repeatingHead.logo) {
+			var logoPosition = (['left','right','center'].indexOf(config.repeatingHead.logoPosition) > 0) ? config.repeatingHead.logoPosition : 'right';
+			html += '<tr><th colspan="'+data.header.length+'" style="padding: 0;margin: 0;text-align: '+logoPosition+';"><img style="'+config.repeatingHead.logoStyle+'" src="'+config.repeatingHead.logo+'"/></th></tr>';
 		}
+		
+		// Adding title (repeats for every page while print)
+		if(config.repeatingHead.title) {
+			html += '<tr><th colspan="'+data.header.length+'">'+config.repeatingHead.title+'</th></tr>';
+		}
+		
+		if ( config.header ) {
+			html += addRow( data.header, 'th' );
+		}
+		
+		html += '</thead>';
 
 		html += '<tbody>';
 		for ( var i=0, ien=data.body.length ; i<ien ; i++ ) {
@@ -193,6 +208,8 @@ DataTable.ext.buttons.print = {
 	messageTop: '*',
 
 	messageBottom: '*',
+	
+	repeatingHead: {},
 
 	exportOptions: {},
 


### PR DESCRIPTION
Added a new option for printing so that people can now repeat their page heading and custom image to every page while printing. Previously this was applicable to first page only.

Below are new options,
```
repeatingHead: {
logo: 'http://example.com/logo.png',
logoPosition: 'right', //left, right, center
logoStyle: 'padding-bottom:5px', 
title: '<h3>Sample Heading</h3>'
}
```

