### PR TITLE
Add clickBlurs parameter to prevent blurring on specific buttons

### DIFF
--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -547,7 +547,7 @@ $.extend( Buttons.prototype, {
 		};
 
 		var tag = config.tag || buttonDom.tag;
-		var clickBlurs = config.clickBlurs == null ? true : config.clickBlurs
+		var clickBlurs = config.clickBlurs === undefined ? true : config.clickBlurs
 		var button = $('<'+tag+'/>')
 			.addClass( buttonDom.className )
 			.attr( 'tabindex', this.s.dt.settings()[0].iTabIndex )

--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -547,6 +547,7 @@ $.extend( Buttons.prototype, {
 		};
 
 		var tag = config.tag || buttonDom.tag;
+		var clickBlurs = config.clickBlurs == null ? true : config.clickBlurs
 		var button = $('<'+tag+'/>')
 			.addClass( buttonDom.className )
 			.attr( 'tabindex', this.s.dt.settings()[0].iTabIndex )
@@ -557,8 +558,9 @@ $.extend( Buttons.prototype, {
 				if ( ! button.hasClass( buttonDom.disabled ) && config.action ) {
 					action( e, dt, button, config );
 				}
-
-				button.blur();
+				if( clickBlurs ) {
+					button.blur();
+				}
 			} )
 			.on( 'keyup.dtb', function (e) {
 				if ( e.keyCode === 13 ) {


### PR DESCRIPTION
Discussion: https://datatables.net/forums/discussion/51832/feature-to-prevent-blur-on-button-click/

Done in the simplest way possible, with preserving the current default behaviour. 
(If there's guidelines of how invalidish input should be handled i.e. if clickBlurs is not a boolean, let me know so I can modify the PR to incorporate the system required). 