### PR TITLE
Fixed column visibility buttons reordering

### DIFF
--- a/js/buttons.colVis.js
+++ b/js/buttons.colVis.js
@@ -123,17 +123,19 @@ $.extend( DataTable.ext.buttons, {
 						return;
 					}
 
-					conf.columns = $.inArray( conf.columns, details.mapping );
-					button.attr( 'data-cv-idx', conf.columns );
+					if (conf.columns !== details.mapping[conf.columns]) {
+						conf.columns = details.mapping[conf.columns];
+						button.attr('data-cv-idx', conf.columns);
 
-					// Reorder buttons for new table order
-					button
-						.parent()
-						.children('[data-cv-idx]')
-						.sort( function (a, b) {
-							return (a.getAttribute('data-cv-idx')*1) - (b.getAttribute('data-cv-idx')*1);
-						} )
-						.appendTo(button.parent());
+						// Reorder buttons for new table order
+						button
+							.parent()
+							.children('[data-cv-idx]')
+							.sort(function (a, b) {
+								return (a.getAttribute('data-cv-idx') * 1) - (b.getAttribute('data-cv-idx') * 1);
+							})
+							.appendTo(button.parent());
+					}
 				} );
 
 			this.active( dt.column( conf.columns ).visible() );


### PR DESCRIPTION
Previously the new 'data-cv-idx' attribute value was assigned from "$.inArray(conf.columns, details.mapping)". Instead "details.mapping[conf.columns]" is now used.

Moreover, re-sorting the buttons is now performed only when the index has really changed.

Merging under MIT license is fine for me of course.