### PR TITLE
added class flex-wrap to button container

### DIFF
--- a/js/buttons.bootstrap4.js
+++ b/js/buttons.bootstrap4.js
@@ -38,7 +38,7 @@ var DataTable = $.fn.dataTable;
 $.extend( true, DataTable.Buttons.defaults, {
 	dom: {
 		container: {
-			className: 'dt-buttons btn-group'
+			className: 'dt-buttons btn-group flex-wrap'
 		},
 		button: {
 			className: 'btn btn-secondary'


### PR DESCRIPTION
This will make a line break on overflowing buttons.

https://datatables.net/forums/discussion/57149/bootstrap-4-table-buttons-small-device
