### PR TITLE
Export hyperlinks to Excel.

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -771,6 +771,7 @@ var excelStrings = {
 // Ref: section 3.8.30 - built in formatters in open spreadsheet
 //   https://www.ecma-international.org/news/TC45_current_work/Office%20Open%20XML%20Part%204%20-%20Markup%20Language%20Reference.pdf
 var _excelSpecials = [
+	{ match: /^=HYPERLINK\(.+\)$/,  style: 4, nodeName: 'f', replace: /^=/ }, // Hyperlink
 	{ match: /^\-?\d+\.\d%$/,       style: 60, fmt: function (d) { return d/100; } }, // Precent with d.p.
 	{ match: /^\-?\d+\.?\d*%$/,     style: 56, fmt: function (d) { return d/100; } }, // Percent
 	{ match: /^\-?\$[\d,]+.?\d*$/,  style: 57 }, // Dollars
@@ -1071,7 +1072,7 @@ DataTable.ext.buttons.excelHtml5 = {
 					// if they are returning a string, since at the moment it is
 					// assumed to be a number
 					if ( row[i].match && ! row[i].match(/^0\d+/) && row[i].match( special.match ) ) {
-						var val = row[i].replace(/[^\d\.\-]/g, '');
+						var val = row[i].replace(special.replace || /[^\d\.\-]/g, '');
 
 						if ( special.fmt ) {
 							val = special.fmt( val );
@@ -1083,7 +1084,7 @@ DataTable.ext.buttons.excelHtml5 = {
 								s: special.style
 							},
 							children: [
-								_createNode( rels, 'v', { text: val } )
+								_createNode( rels, special.nodeName || 'v', { text: val } )
 							]
 						} );
 


### PR DESCRIPTION
_Inspired by https://stackoverflow.com/questions/40243616/jquery-datatables-export-to-excelhtml5-hyperlink-issue/49146977_

This patch extends the special formatting capability of the Excel exporter to detect the "=FUNCTION(...)" signature customary in Excel, specifically for hyperlinks.

This PR does not attempt to solve the broader hyperlink rendering issue, though along the lines of the fourth example at https://datatables.net/reference/option/columns.render#Examples, a user could add a renderer for a custom 'excel' orthogonal:
```
$('#example').dataTable( {
  columnDefs: [ {
    render: {
      display: function ( data, type, row, meta ) {
        return '<a href="'+data+'">Download</a>';
      },
      excel: function ( data, type, row, meta ) {
        return '=HYPERLINK("'+data+'",'"Download"')';
      },
    }
  }]
});
```
then configure the export button to use it:
```
$('#report').dataTable({
  buttons: [{
    extend: 'excel',
    exportOptions: {
      orthogonal: 'excel',
    },
  }]
});
```