### PR TITLE
Fix bug when try customize the exported data

### DIFF
--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -1958,7 +1958,7 @@ var _exportData = function ( dt, inOpts )
 	};
 
 	if ( config.customizeData ) {
-		config.customizeData( data );
+		data = config.customizeData( data );
 	}
 
 	return data;


### PR DESCRIPTION
I need remove duplicated rows that occurs when one or more columns are not displayed (ColVis) use the callback `customizeData` is the best way extending the button and using configuration, but it isn't overwrite the variable, I can only read the value
```js
$.extend(true, $.fn.dataTable.ext.buttons, {
    separatedValues: {
        className: 'buttons-sv-export',
        text: '<i class="fa fa-file-excel-o"></i> separatedValues',
        exportData: {
            modifier: {
                selected: true
            },
            columns: ':visible'
        },
        exportOptions: {
            customizeData : function(data){
                var bodySeen = {};
                var bodyDistincted = [];
                var j = 0;
                for (var i = 0; i < data.body.length; i++) {
                    var item = data.body[i];
                    if (bodySeen[item] !== 1) {
                        bodySeen[item] = 1;
                        bodyDistincted[j++] = item;
                    }
                }

                data.body = bodyDistincted;

                return data;
            }
        },
        extend: 'csvHtml5',
    },
});
```