### PR TITLE
Replace deprecated jQuery event shorthand

### DIFF
--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -576,7 +576,7 @@ $.extend( Buttons.prototype, {
 					action( e, dt, button, config );
 				}
 				if( clickBlurs ) {
-					button.blur();
+					button.trigger('blur');
 				}
 			} )
 			.on( 'keyup.dtb', function (e) {


### PR DESCRIPTION
jQuery event shorthands are marked as deprecated and removed in recent jQuery versions.

> jQuery.fn.blur() event shorthand is deprecated