### PR TITLE
Fix: cross reference of `buttons.buttons.split`

### DIFF
--- a/docs/option/buttons.buttons.split.xml
+++ b/docs/option/buttons.buttons.split.xml
@@ -17,7 +17,7 @@ This option allows for split button functionality with all DataTables buttons.
 
 To implement split buttons simply extend any existing button type to include the `-init buttons.buttons.split` config option, or include it within your custom buttons initialisation. The value of this option is an array that contains further buttons which are to be added as secondary buttons. The buttons within this array can be declared in the same form as the `-init buttons.buttons` option, please read that documentation for full details.
 
-As of Buttons 2.0.0 it is possible to add custom html to collections. Simply include a string containing the html into the `-init buttons.buttons.split` array and it will be inserted in that order into the collection popover. [This example](//datatables.net/extensions/Buttons/examples/initialisation/customHTMLButtons.html) shows how this can be used to create more powerful popovers.
+As of Buttons 2.0.0 it is possible to add custom html to collections. Simply include a string containing the html into the `-init buttons.buttons.split` array and it will be inserted in that order into the collection popover. [This example](//datatables.net/extensions/buttons/examples/initialisation/customHTMLButtons.html) shows how this can be used to create more powerful popovers.
 
 Note: Bulma does not support split button dropdowns at the time of creating the styling integrations. Because of this, split buttons are not supported in Bulma. This will be updated in the future if Bulma begin supporting split buttons.
 	</description>

--- a/examples/split/bootstrap.xml
+++ b/examples/split/bootstrap.xml
@@ -27,7 +27,7 @@ $(document).ready(function() {
 
 <info><![CDATA[
 
-The `-init butttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
+The `-init buttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
 
 This example shows DataTables and the Buttons extension being used to create split buttons, with the [Bootstrap](http://getbootstrap.com) framework providing the styling.
 

--- a/examples/split/bootstrap4.xml
+++ b/examples/split/bootstrap4.xml
@@ -27,7 +27,7 @@ $(document).ready(function() {
 
 <info><![CDATA[
 
-The `-init butttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
+The `-init buttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
 
 This example shows DataTables and the Buttons extension being used to create split buttons, with the [Bootstrap 4](http://getbootstrap.com/) framework providing the styling.
 

--- a/examples/split/bootstrap5.xml
+++ b/examples/split/bootstrap5.xml
@@ -27,7 +27,7 @@ $(document).ready(function() {
 
 <info><![CDATA[
 
-The `-init butttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
+The `-init buttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
 
 This example shows DataTables and the Buttons extension being used to create split buttons, with the [Bootstrap 5](http://getbootstrap.com/) framework providing the styling.
 

--- a/examples/split/bulma.xml
+++ b/examples/split/bulma.xml
@@ -28,7 +28,7 @@ $(document).ready(function() {
 
 <info><![CDATA[
 
-The `-init butttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
+The `-init buttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
 
 This example shows DataTables and the Buttons extension being used to create split buttons, with the [Bulma](https://bulma.io/) framework providing the styling.
 

--- a/examples/split/dataTables.xml
+++ b/examples/split/dataTables.xml
@@ -24,7 +24,7 @@ $(document).ready(function() {
 
 <info><![CDATA[
 
-The `-init butttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
+The `-init buttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
 
 ]]></info>
 

--- a/examples/split/foundation.xml
+++ b/examples/split/foundation.xml
@@ -27,7 +27,7 @@ $(document).ready(function() {
 
 <info><![CDATA[
 
-The `-init butttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
+The `-init buttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
 
 This example shows DataTables and the Buttons extension being used to create split buttons, with the [Foundation](http://foundation.zurb.com) framework providing the styling.
 

--- a/examples/split/jqueryui.xml
+++ b/examples/split/jqueryui.xml
@@ -27,7 +27,7 @@ $(document).ready(function() {
 
 <info><![CDATA[
 
-The `-init butttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
+The `-init buttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover. 
 
 This example shows DataTables and Buttons being used to create split buttons, with [jQuery UI](http://jqueryui.com/) providing the base styling information.
 

--- a/examples/split/semanticui.xml
+++ b/examples/split/semanticui.xml
@@ -26,7 +26,7 @@ $(document).ready(function() {
 <title lib="Buttons">Semantic UI styling</title>
 
 <info><![CDATA[
-The `-init butttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover.
+The `-init buttons.buttons.split` option allows for "split dropdown buttons" to be introduced into DataTables. This allows the main button to perform a primary action while the drop down is able to provide a number of secondary options in a popover.
 
 This example shows DataTables and the Buttons extension being used to create split buttons, with the [Semantic UI](http://semantic-ui.com/) framework providing the styling.
 


### PR DESCRIPTION
Hey there,

Browsing a bit through the documentation I came across a 404 via https://datatables.net/reference/option/butttons.buttons.split.

![image](https://user-images.githubusercontent.com/14982812/139589227-3fda0ca2-571e-47a5-b7ed-1cf52ae46137.png)

Current example (first link): https://datatables.net/extensions/buttons/examples/split/dataTables.html

I'm not that familiar with how the entire documentation is built up, but I hope that this PR can simply fix it.

BR,
Marco
