### PR TITLE
Add spacer button style definition

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -430,6 +430,11 @@ declare module 'datatables.net' {
 		extend?: string;
 
 		/**
+		 * Define spacer button style
+		 */
+		style?: string;
+
+		/**
 		 * Initialisation function that can be used to add events specific to this button
 		 */
 		init?: FunctionButtonInit;


### PR DESCRIPTION
According to documentation [docs](https://datatables.net/reference/button/spacer) spacer should have "style"

Fix error: TS2322: Type '{ extend: string; style: string; text: string; }' is not assignable to type 'ButtonSettings'.   Object literal may only specify known properties, and 'style' does not exist in type 'ButtonSettings'.