### PR TITLE
Fix: Excel AutoFilter range format was incorrect

### DIFF
--- a/docs/button/excelHtml5.xml
+++ b/docs/button/excelHtml5.xml
@@ -222,7 +222,7 @@
 	</option>
 
 	<option type="boolean" name="autoFilter" default="false" since="1.5.4">
-		Enable Excel's auto filter feature for the header cells in the table allowing the user to quickly filter and sort the exported spreadsheet in Excel. Note that this does not operate in LibreOffice (although the spreadsheet is still readable).
+		Enable Excel's auto filter feature for the header cells in the table allowing the user to quickly filter and sort the exported spreadsheet in Excel.
 	</option>
 
 

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -1348,8 +1348,9 @@ DataTable.ext.buttons.excelHtml5 = {
 						_sheetname(config) +
 						'!$A$' +
 						dataStartRow +
-						':' +
+						':$' +
 						createCellPos(data.header.length - 1) +
+						'$' +
 						dataEndRow
 				})
 			);


### PR DESCRIPTION
Maybe Excel is ok without these changes, but this at least makes AutoFilter work in LibreOffice and is the format LibreOffice uses when saving to XLSX format.

Gnumeric seems to behave the same before and after: for some reason it requires (double) clicking in (into cell edit mode) and clicking out of a header column for the auto filter controls to appear?