### PR TITLE
Fix: Quote Excel sheet name in case it contains spaces

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -1345,8 +1345,9 @@ DataTable.ext.buttons.excelHtml5 = {
 						hidden: 1
 					},
 					text:
-						_sheetname(config) +
-						'!$A$' +
+						'\'' +
+						_sheetname(config).replace(/'/g, '\'\'') +
+						'\'!$A$' +
 						dataStartRow +
 						':' +
 						createCellPos(data.header.length - 1) +


### PR DESCRIPTION
This fixes errors/warnings with some spreadsheet software, including Gnumeric.