### PR TITLE
Fix missing call to cb in "copy" when clicking to cancel prompt

### DIFF
--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -969,7 +969,10 @@ DataTable.ext.buttons.copyHtml5 = {
 			dt.buttons.info(false);
 		};
 
-		container.on('click.buttons-copy', close);
+		container.on('click.buttons-copy', function () {
+			close();
+			cb();
+		});
 		$(document)
 			.on('keydown.buttons-copy', function (e) {
 				if (e.keyCode === 27) {


### PR DESCRIPTION
In export to clipboard (copy).
When `document.execCommand('copy')` is unsuccessful.
A prompt with instructions to copy is displayed.

If we cancel the prompt by using the ESC key, the callback function `cb` is called.

But if we cancel the prompt by clicking on it, the callback function `cb` is not called.

`cb`should be called in all cancel scenarios.
This PR fixes it.