### PR TITLE
Fix: Avoid innerHTML in print button to comply with CSP

### DIFF
--- a/js/buttons.print.js
+++ b/js/buttons.print.js
@@ -166,19 +166,20 @@ DataTable.ext.buttons.print = {
 		win.document.close();
 
 		// Inject the title and also a copy of the style and link tags from this
-		// document so the table can retain its base styling. Note that we have
-		// to use string manipulation as IE won't allow elements to be created
-		// in the host document and then appended to the new window.
-		var head = '<title>' + exportInfo.title + '</title>';
-		$('style, link').each(function () {
-			head += _styleToAbs(this);
-		});
+		// document so the table can retain its base styling. This avoids 
+        // issues with Content Security Policy (CSP) and is compatible with modern browsers.
 
-		try {
-			win.document.head.innerHTML = head; // Work around for Edge
-		} catch (e) {
-			$(win.document.head).html(head); // Old IE
-		}
+		win.document.title = exportInfo.title;
+
+	    $('style, link[rel="stylesheet"]').each(function () {
+	      let node = this.cloneNode(true);
+	      
+	      if (node.tagName.toLowerCase() === 'link') {
+	        node.href = _relToAbs(node.href);
+	       }
+
+	       win.document.head.appendChild(node);
+	    });
 
 		// Add any custom scripts (for example for paged.js)
 		if (config.customScripts) {


### PR DESCRIPTION
This avoids issues with Content Security Policy (CSP) restrictions that prevent us from injecting inline styles or relying on script-based styling.
By cloning and appending the stylesheets, we preserve the look and feel of the printed table without triggering CSP violations. Also added a fix to convert relative URLs to absolute ones for linked stylesheets—helps avoid broken styles in the new window.
Should be a solid step toward making print/export more reliable across browsers and environments with strict CSP settings.