### PR TITLE
Fix Excel AutoFilter export so it works with LibreOffice.

### DIFF
--- a/examples/html5/excelAutoFilter.xml
+++ b/examples/html5/excelAutoFilter.xml
@@ -46,7 +46,7 @@ new DataTable('#example', {
 
 <info><![CDATA[
 
-Excel has an [AutoFilter](https://support.office.com/en-us/article/use-autofilter-to-filter-your-data-7d87d63e-ebd0-424b-8106-e2ab61133d92) feature which lets the end user quickly filter and sort data in the exported spreadsheet. To enable this feature on the header cells of the exported table, use the `autoFilter` option of the `-button excelHtml5` button type. Please note that the AutoFilter feature does no operate in LibreOffice, but the spreadsheet is still readable - this is a feature specific to Excel.
+Excel has an [AutoFilter](https://support.office.com/en-us/article/use-autofilter-to-filter-your-data-7d87d63e-ebd0-424b-8106-e2ab61133d92) feature which lets the end user quickly filter and sort data in the exported spreadsheet. To enable this feature on the header cells of the exported table, use the `autoFilter` option of the `-button excelHtml5` button type.
 
 This example also shows the use of the `sheetName` option which allows the sheet in the exported workbook to be given a defined name.
 

--- a/js/buttons.html5.js
+++ b/js/buttons.html5.js
@@ -1354,8 +1354,9 @@ DataTable.ext.buttons.excelHtml5 = {
 						_sheetname(config).replace(/'/g, '\'\'') +
 						'\'!$A$' +
 						dataStartRow +
-						':' +
+						':$' +
 						createCellPos(data.header.length - 1) +
+						'$' +
 						dataEndRow
 				})
 			);


### PR DESCRIPTION
LibreOffice supports AutoFilter with correctly defined ranges.  These commits fix the exported workbook and documentation.